### PR TITLE
feat: add Playwright API tests, workspace structure and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,28 @@
 # Node.js
 node_modules/
-package-lock.json
-
-# Cypress
-cypress/screenshots/
-cypress/videos/
-
-# Logs
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+package-lock.json
 
-# VS Code settings
+# Cypress
+cypress/videos/
+cypress/screenshots/
+cypress/downloads/
+
+# Playwright
+playwright/test-results/
+playwright/report/
+playwright/.cache/
+playwright/playwright-report/
+playwright/.playwright/
+
+# VS Code
 .vscode/
 
-# OS-specific
+# macOS
 .DS_Store
-Thumbs.db
 
-# Environment / temp
-.env
-.env.local
-*.log
+# IDEs
+.idea/
+*.sw?

--- a/README.md
+++ b/README.md
@@ -18,26 +18,25 @@ sdet-portfolio/
 │   ├── support/                       # Custom commands, setup logic
 │   └── test-data/                     # Test data (e.g. login credentials)
 ├── playwright/
-│   ├── tests/                         # End-to-end test specs
+│   ├── e2e/                           # End-to-end test specs
+│   │   ├── api/                       # API-related tests
+│   │   └── ui/
+│   │       ├── cart/                  # Cart-related tests
+│   │       └── login/                 # Login-related tests
 │   ├── page-objects/                  # Page Object Model structure
-│   ├── playwright.config.ts           # Playwright configuration
-│   ├── package.json                   # Playwright dependencies and scripts
-│   └── tsconfig.json                  # TypeScript configuration for Playwright
-├── cypress.config.js                  # Cypress configuration
-├── package.json                       # Project metadata and Cypress dependencies
+│   └── test-data/                     # Test data (e.g. login credentials)
 └── README.md                          # Project documentation (this file)
 ```
 
 ## What’s Covered
 
-- Login flow (valid and invalid credentials)
+- Cypress Login flow (valid and invalid credentials)
+- Cypress Cart functionality coverage (add, remove, total, checkout)
+- Cypress API validation tests
+- Initial Playwright Login flow and API test
 - Page Object Model (POM) architecture
-- Custom Cypress commands
 - Test data separation
 - Assertions on login feedback and UI elements
-- API validation tests
-- Cart functionality coverage (add, remove, total, checkout)
-- Initial Playwright login flow using POM
 
 ## Getting Started
 
@@ -57,39 +56,19 @@ npm install
 ### Run Tests (Cypress GUI)
 
 ```bash
-npx cypress open
+npm run open --workspace=cypress
 ```
 
 ### Run Tests (Cypress Headless)
 
 ```bash
-npx cypress run
+npm run run --workspace=cypress
 ```
 
-### Run Tests (Playwright)
-
-Navigate to the Playwright folder:
+### Run Tests (Playwright Headless)
 
 ```bash
-cd playwright
-```
-
-Install required browsers:
-
-```bash
-npx playwright install
-```
-
-Run tests in headless mode:
-
-```bash
-npx playwright test
-```
-
-Run tests in headed (UI) mode:
-
-```bash
-npx playwright test --headed
+npm run test --workspace=playwright
 ```
 
 ## Design Principles

--- a/cypress/cypress.config.js
+++ b/cypress/cypress.config.js
@@ -10,7 +10,7 @@ module.exports = defineConfig({
         }
       });
     },
-    specPattern: 'cypress/e2e/**/*.cy.js',
-    supportFile: 'cypress/support/e2e.js'
+    specPattern: 'e2e/**/*.cy.js',
+    supportFile: 'support/e2e.js'
   }
 });

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "cypress-tests",
+    "version": "1.0.0",
+    "description": "UI and API tests for SauceDemo using Cypress + JavaScript as part of the SDET Portfolio project.",
+    "main": "cypress.config.js",
+    "scripts": {
+      "open": "cypress open",
+      "run": "cypress run"
+    },
+    "author": "Víctor Martín Aller",
+    "license": "MIT",
+    "devDependencies": {
+      "cypress": "^14.2.1"
+    }
+  }
+  

--- a/package.json
+++ b/package.json
@@ -1,31 +1,9 @@
 {
   "name": "sdet-portfolio",
   "version": "1.0.0",
-  "description": "This is my public SDET portfolio project built with JavaScript and Cypress, and TypeScript with Playwright, targeting the demo website SauceDemo.",
-  "main": "cypress.config.js",
- "scripts": {
-    "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/garontherocks/sdet-portfolio.git"
-  },
-  "keywords": [
+  "private": true,
+  "workspaces": [
     "cypress",
-    "qa",
-    "automation",
-    "testing",
-    "e2e",
-    "portfolio"
-  ],
-  "author": "Victor",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/garontherocks/sdet-portfolio/issues"
-  },
-  "homepage": "https://github.com/garontherocks/sdet-portfolio#readme",
-  "devDependencies": {
-    "cypress": "^14.2.1"
-  }
+    "playwright"
+  ]
 }

--- a/playwright/e2e/api/README.md
+++ b/playwright/e2e/api/README.md
@@ -1,0 +1,7 @@
+# API Tests (reqres.in)
+
+This directory contains API automation tests against the [reqres.in](https://reqres.in) service:
+
+- User creation (POST)
+
+These tests demonstrate the use of Playwright for REST API testing using the built-in request fixture, including status code handling and response validation.

--- a/playwright/e2e/api/create-user.spec.ts
+++ b/playwright/e2e/api/create-user.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { users } from '../../test-data/users';
+
+test.describe('ReqRes API - Create User', () => {
+    const { apiCreateUser } = users;
+  test('should create a new user successfully', async ({ request }) => {
+    const response = await request.post('https://reqres.in/api/users', {
+      data: {
+        name: apiCreateUser.name,
+        job: apiCreateUser.job
+      }
+    });
+
+    expect(response.status()).toBe(201);
+
+    const responseBody = await response.json();
+    expect(responseBody).toHaveProperty('id');
+    expect(responseBody).toHaveProperty('createdAt');
+  });
+});

--- a/playwright/e2e/ui/README.md
+++ b/playwright/e2e/ui/README.md
@@ -1,0 +1,7 @@
+# Login UI Tests
+
+This directory contains automated login tests for the SauceDemo website using Playwright:
+
+- Successful login with valid credentials
+
+These tests use the Page Object Model to encapsulate login page interactions, and load user credentials from `test-data/users.ts`.

--- a/playwright/e2e/ui/login.spec.ts
+++ b/playwright/e2e/ui/login.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { LoginPage } from '../page-objects/LoginPage';
-import { users } from '../test-data/users';
+import { LoginPage } from '../../page-objects/LoginPage';
+import { users } from '../../test-data/users';
 
 test.describe('SauceDemo - Login', () => {
   let loginPage: LoginPage;

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-tests",
   "version": "1.0.0",
-  "description": "UI tests for SauceDemo using Playwright + TypeScript as part of the SDET Portfolio project.",
+  "description": "UI and API tests for SauceDemo using Playwright + TypeScript as part of the SDET Portfolio project.",
   "main": "index.js",
   "scripts": {
     "test": "npx playwright test",

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -12,7 +12,7 @@ import { defineConfig, devices } from '@playwright/test';
  * See https://playwright.dev/docs/test-configuration.
  */
 export default defineConfig({
-  testDir: './tests',
+  testDir: './e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright/test-data/users.ts
+++ b/playwright/test-data/users.ts
@@ -6,5 +6,9 @@ export const users = {
   lockedOut: {
     username: 'locked_out_user',
     password: 'secret_sauce',
+  },
+  apiCreateUser: {
+    name: 'John',
+    job: 'SDET'
   }
 };


### PR DESCRIPTION
- Added Playwright API tests (create user and login failure using reqres.in)
- Restructured `playwright` folder to use `/e2e/api` and `/e2e/ui` directories
- Created README.md for API and UI test folders following existing Cypress style
- Refactored test data into `test-data/users.ts` for better maintainability
- Updated Playwright config to point to new `e2e` structure
- Converted project to use npm workspaces:
  - Cypress and Playwright have independent `package.json` files
  - Moved `cypress.config.js` into `/cypress`
  - Updated root `package.json` to define workspaces
- Cleaned `.gitignore` to support monorepo and reports