### PR TITLE
chore(ci): add GitHub Actions pipeline for k6 performance testing

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     defaults:
       run:
-        working-directory: playwright
+        working-directory: performance
 
     steps:
       - name: Checkout repository
@@ -27,4 +27,4 @@ jobs:
           sudo apt install -y k6
 
       - name: Run k6 smoke test
-        run: k6 run performance/smoke.test.js
+        run: k6 run smoke.test.js

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -17,9 +17,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install k6
-        run: |
-          curl -s https://packagecloud.io/install/repositories/loadimpact/k6/script.deb.sh | sudo bash
-          sudo apt-get install k6
+          run: |
+            sudo apt update
+            sudo apt install -y gnupg software-properties-common
+            sudo mkdir -p /etc/apt/keyrings
+            curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/k6.gpg
+            echo "deb [signed-by=/etc/apt/keyrings/k6.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+            sudo apt update
+            sudo apt install -y k6
 
       - name: Run k6 smoke test
         run: k6 run performance/smoke.test.js

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -17,14 +17,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install k6
-          run: |
-            sudo apt update
-            sudo apt install -y gnupg software-properties-common
-            sudo mkdir -p /etc/apt/keyrings
-            curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/k6.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/k6.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
-            sudo apt update
-            sudo apt install -y k6
+        run: |
+          sudo apt update
+          sudo apt install -y gnupg software-properties-common
+          sudo mkdir -p /etc/apt/keyrings
+          curl -fsSL https://dl.k6.io/key.gpg | sudo gpg --dearmor -o /etc/apt/keyrings/k6.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/k6.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+          sudo apt update
+          sudo apt install -y k6
 
       - name: Run k6 smoke test
         run: k6 run performance/smoke.test.js

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -1,0 +1,25 @@
+name: K6 Performance Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  k6-run:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: playwright
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install k6
+        run: |
+          curl -s https://packagecloud.io/install/repositories/loadimpact/k6/script.deb.sh | sudo bash
+          sudo apt-get install k6
+
+      - name: Run k6 smoke test
+        run: k6 run performance/smoke.test.js

--- a/README.md
+++ b/README.md
@@ -99,6 +99,18 @@ npm run percy:playwright --workspace=playwright
 
 - Percy build results are available at [percy.io](https://percy.io)
 
+## 🚀 Performance Testing (k6)
+
+k6 integration enabled for load and smoke testing.
+
+Performance test scripts are stored under `playwright/performance`.
+
+Run manually:
+
+```bash
+k6 run performance/smoke.test.js
+```
+
 ## Code Quality & Linting
 
 - ESLint checks run locally and in CI (GitHub Actions).

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Run manually:
 k6 run performance/smoke.test.js
 ```
 
+Executed automatically via GitHub Actions on push/PR.
+
 ## Code Quality & Linting
 
 - ESLint checks run locally and in CI (GitHub Actions).
@@ -142,6 +144,7 @@ npm run lint:fix                        # Auto-fix fixable issues
 | Percy       | Visual regression testing   |
 | ESLint      | Code quality                |
 | Husky       | Pre-commit enforcement      |
+| k6          | Load/Stress Test            |
 
 ## Roadmap
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "lhci": "lhci autorun"
+    "lhci": "lhci autorun",
+    "k6:smoke": "k6 run performance/smoke.test.js"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",
@@ -26,6 +27,7 @@
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.0.0",
     "husky": "^9.1.7",
+    "k6": "^0.0.0",
     "lint-staged": "^15.5.0",
     "typescript-eslint": "^8.29.0"
   },

--- a/performance/smoke.test.js
+++ b/performance/smoke.test.js
@@ -1,0 +1,15 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export const options = {
+  vus: 10, // virtual users
+  duration: '10s',
+};
+
+export default function () {
+  const res = http.get('https://www.saucedemo.com/');
+  check(res, {
+    'status is 200': (r) => r.status === 200,
+  });
+  sleep(1);
+}


### PR DESCRIPTION
- Created k6-run job to run on push/pull_request

- Installed k6 via packagecloud installer

- Runs a simple smoke test at performance/smoke.test.js

- Sets up for future performance benchmarks